### PR TITLE
Use phone icon in infobox if url scheme is "tel"

### DIFF
--- a/DP3TApp/Logic/Helpers/PhoneCallHelper.swift
+++ b/DP3TApp/Logic/Helpers/PhoneCallHelper.swift
@@ -14,7 +14,10 @@ class PhoneCallHelper: NSObject {
     // MARK: - API
 
     public static func call(_ phoneNumber: String) {
-        let callableNumber = phoneNumber.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "+", with: "00")
+        let callableNumber = phoneNumber
+            .replacingOccurrences(of: "tel:", with: "")
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "+", with: "00")
 
         if let url = URL(string: "tel://\(callableNumber)") {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/DP3TApp/Screens/WhatToDo/NSWhatToDoInformModuleView.swift
+++ b/DP3TApp/Screens/WhatToDo/NSWhatToDoInformModuleView.swift
@@ -68,6 +68,7 @@ class NSWhatToDoInformModuleView: NSSimpleModuleBaseView {
                                                 additionalURL: infoBox.url?.absoluteString,
                                                 dynamicIconTintColor: .ns_purple,
                                                 externalLinkStyle: .normal(color: .ns_purple),
+                                                externalLinkType: infoBox.url?.scheme == "tel" ? .phone : .url,
                                                 hearingImpairedButtonCallback: hearingImpairedCallback)
 
             model.image = UIImage(named: "ic-info")


### PR DESCRIPTION
If the URL scheme is "tel", the button should have a link type of "phone" and display a phone icon, instead of the usual external link icon.