### PR TITLE
Put checkout action on top

### DIFF
--- a/DP3TApp/Logic/NSLocalPush.swift
+++ b/DP3TApp/Logic/NSLocalPush.swift
@@ -390,10 +390,10 @@ class NSLocalPush: NSObject, LocalPushProtocol {
 
         center.setNotificationCategories([UNNotificationCategory(identifier: Identifiers.checkInReminder.rawValue,
                                                                  actions: [
+                                                                     Actions.checkOut.action,
                                                                      Actions.checkOutSnooze30min.action,
                                                                      Actions.checkOutSnooze1h.action,
                                                                      Actions.checkOutSnooze2h.action,
-                                                                     Actions.checkOut.action,
                                                                  ],
                                                                  intentIdentifiers: [], options: [])])
 


### PR DESCRIPTION
This puts the "checkout" action on top of the list of actions when longpressing on a checkout reminder notification (better UX).