### PR TITLE
Fix image buttons and bold text on iOS 12

### DIFF
--- a/DP3TApp/SharedUI/Controls/NSButton.swift
+++ b/DP3TApp/SharedUI/Controls/NSButton.swift
@@ -103,7 +103,6 @@ class NSButton: UBButton {
 
         highlightCornerRadius = 3
         layer.cornerRadius = 3
-        contentEdgeInsets = UIEdgeInsets(top: NSPadding.medium, left: NSPadding.large, bottom: NSPadding.medium, right: NSPadding.large)
 
         titleLabel?.numberOfLines = 2
 
@@ -130,12 +129,15 @@ class NSButton: UBButton {
     override var intrinsicContentSize: CGSize {
         var contentSize = super.intrinsicContentSize
 
-        if contentSize.height > 44.0 {
+        contentSize.height = max(contentSize.height, 44)
+        if contentSize.height > 44 {
             contentSize.height += NSPadding.medium
         }
 
         if let img = imageView?.image {
             contentSize.width += 2 * (img.size.width + 12)
+        } else {
+            contentSize.width += 2 * NSPadding.large
         }
 
         return contentSize
@@ -145,8 +147,10 @@ class NSButton: UBButton {
         super.layoutSubviews()
 
         if let img = imageView?.image {
-            imageEdgeInsets = UIEdgeInsets(top: 0, left: bounds.width - 12 - img.size.width, bottom: 0, right: 12)
-            titleEdgeInsets = UIEdgeInsets(top: 0, left: img.size.width / 2, bottom: 0, right: -img.size.width / 2)
+            let contentWidth = (img.size.width + (titleLabel?.intrinsicContentSize.width ?? 0)) / 2
+            let offset = contentWidth + bounds.width / 2 - img.size.width - 12
+            imageEdgeInsets = UIEdgeInsets(top: 0, left: offset, bottom: 0, right: -offset)
+            titleEdgeInsets = UIEdgeInsets(top: 0, left: -img.size.width / 2, bottom: 0, right: img.size.width / 2)
         }
     }
 

--- a/DP3TApp/SharedUI/Style/NSLabelType.swift
+++ b/DP3TApp/SharedUI/Style/NSLabelType.swift
@@ -181,12 +181,31 @@ class NSLabel: UBLabel<NSLabelType> {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            guard let text = attributedText else { return }
+            let mutableText = NSMutableAttributedString(attributedString: text)
             font = labelType.font
+            mutableText.replaceFont(with: labelType.font)
+            attributedText = mutableText
         }
     }
 
     public var lineDistance: CGFloat {
         (labelType.lineSpacing - 1.0) * font.lineHeight
+    }
+}
+
+extension NSMutableAttributedString {
+    func replaceFont(with font: UIFont) {
+        beginEditing()
+        enumerateAttribute(.font, in: NSRange(location: 0, length: length)) { value, range, _ in
+            if let f = value as? UIFont {
+                let ufd = f.fontDescriptor.withFamily(f.familyName).withSymbolicTraits(f.fontDescriptor.symbolicTraits)!
+                let newFont = UIFont(descriptor: ufd, size: font.pointSize)
+                removeAttribute(.font, range: range)
+                addAttribute(.font, value: newFont, range: range)
+            }
+        }
+        endEditing()
     }
 }
 


### PR DESCRIPTION
This PR fixes two UI problems on iOS 12:
- Titles of buttons with icons were not centered correctly.
- Labels with `attributedText` (e.g. with some bold parts) were not displayed correctly.