### PR TITLE
Don't delete oldestENKeyDate too early

### DIFF
--- a/DP3TApp/Screens/Homescreen/InformBroadcast/NSInformSendViewController.swift
+++ b/DP3TApp/Screens/Homescreen/InformBroadcast/NSInformSendViewController.swift
@@ -116,7 +116,7 @@ class NSInformSendViewController: NSViewController {
         FakePublishManager.shared.rescheduleFakeRequest(force: true)
         UBPushManager.shared.setActive(false)
         UIStateManager.shared.refresh()
-        ReportingManager.shared.reset()
+        defer { ReportingManager.shared.reset() } // Needed so ´oldestENKeyDate´ is still set when next viewcontroller is created
 
         if skipThankYou {
             navigationController?.pushViewController(NSInformTracingEndViewController(), animated: true)


### PR DESCRIPTION
This PR fixes a bug where the `oldestENKeyDate` would be reset too early, causing the "thank you" screen to not display the time range for which EN keys were shared.