### PR TITLE
Don't sync in applicationDidBecomeActive

### DIFF
--- a/DP3TApp/Logic/AppDelegate.swift
+++ b/DP3TApp/Logic/AppDelegate.swift
@@ -131,8 +131,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidBecomeActive(_: UIApplication) {
         // Start sync after app became active
         TracingManager.shared.updateStatus(shouldSync: true, completion: nil)
-
-        ProblematicEventsManager.shared.sync { _, _ in }
     }
 
     private func willAppearAfterColdstart(_: UIApplication, coldStart: Bool, backgroundTime: TimeInterval) {


### PR DESCRIPTION
This PR fixes a wrong behavior that caused a sync of problematic events in every `applicationDidBecomeActive`.