### PR TITLE
Fix silent push logic

### DIFF
--- a/DP3TApp/Logic/CheckIn/CheckInManager/CheckInManager.swift
+++ b/DP3TApp/Logic/CheckIn/CheckInManager/CheckInManager.swift
@@ -67,7 +67,7 @@ class CheckInManager {
         if var cc = currentCheckIn, let outTime = cc.checkOutTime {
             ReminderManager.shared.removeAllReminders()
 
-            if !TracingManager.shared.isActivated {
+            if !TracingManager.shared.isAuthorized {
                 UBPushManager.shared.setActive(true)
             }
 

--- a/DP3TApp/Logic/Push/UBPush/UBPushManager.swift
+++ b/DP3TApp/Logic/Push/UBPush/UBPushManager.swift
@@ -71,7 +71,6 @@ open class UBPushManager: NSObject {
                                               pushRegistrationManager: UBPushRegistrationManager) {
         self.pushHandler = pushHandler
         self.pushRegistrationManager = pushRegistrationManager
-        self.pushRegistrationManager.sendPushRegistrationIfOutdated()
         self.pushHandler.handleLaunchOptions(launchOptions)
 
         if isActive {
@@ -85,6 +84,8 @@ open class UBPushManager: NSObject {
             registerForPushNotification()
         } else if isActive, !active {
             pushRegistrationManager.setPushToken(nil)
+        } else if active {
+            pushRegistrationManager.sendPushRegistrationIfOutdated()
         }
 
         isActive = active

--- a/DP3TApp/Logic/Push/UBPush/UBPushRegistrationManager.swift
+++ b/DP3TApp/Logic/Push/UBPush/UBPushRegistrationManager.swift
@@ -91,6 +91,7 @@ open class UBPushRegistrationManager {
             }
         }
 
+        task?.cancel()
         task = session.dataTask(with: registrationRequest, completionHandler: { [weak self] data, _, error in
             guard let self = self else {
                 return

--- a/DP3TApp/Screens/Homescreen/InformBroadcast/NSInformSendViewController.swift
+++ b/DP3TApp/Screens/Homescreen/InformBroadcast/NSInformSendViewController.swift
@@ -114,7 +114,6 @@ class NSInformSendViewController: NSViewController {
         UserStorage.shared.tracingWasEnabledBeforeIsolation = UserStorage.shared.tracingSettingEnabled
         UserStorage.shared.tracingSettingEnabled = false
         FakePublishManager.shared.rescheduleFakeRequest(force: true)
-        UBPushManager.shared.setActive(false)
         UIStateManager.shared.refresh()
         defer { ReportingManager.shared.reset() } // Needed so ´oldestENKeyDate´ is still set when next viewcontroller is created
 


### PR DESCRIPTION
This PR adjusts the silent push logic to adhere to the [documentation](https://github.com/SwissCovid/swisscovid-doc/blob/main/crowdnotifier/03-background-synchronisation.md#when-does-the-swisscovid-app-register-for-silent-pushes).