### PR TITLE
Don't show tracing errors on the homescreen if user has deactivated tracing

### DIFF
--- a/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
+++ b/DP3TApp/Logic/Tracing/UIState/UIStateLogic.swift
@@ -251,7 +251,7 @@ class UIStateLogic {
             newState.homescreen.reports.backgroundUpdateProblem = st.backgroundRefreshState != .available
         }
 
-        if manager.immediatelyShowSyncError {
+        if UserStorage.shared.tracingSettingEnabled, manager.immediatelyShowSyncError { // Only show EN sync errors if user has enabled tracing
             if manager.syncErrorIsNetworkError {
                 newState.homescreen.reports.syncProblemNetworkingError = true
             } else {


### PR DESCRIPTION
This PR makes sure sync errors from the DP3TSDK are never shown on the homescreen if the user has manually deactivated tracing.