### PR TITLE
Fixes PDF Labels for languages with special characters

### DIFF
--- a/DP3TApp.xcodeproj/project.pbxproj
+++ b/DP3TApp.xcodeproj/project.pbxproj
@@ -4662,7 +4662,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/CrowdNotifier/crowdnotifier-sdk-ios";
 			requirement = {
-				branch = "feature/swisscovid-integration";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DP3TApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
         "package": "CrowdNotifierSDK",
         "repositoryURL": "https://github.com/CrowdNotifier/crowdnotifier-sdk-ios",
         "state": {
-          "branch": "feature/swisscovid-integration",
-          "revision": "c9594f786632fde737ad11af35a61c7f730d82aa",
+          "branch": "develop",
+          "revision": "32026dbc6ce32f110ea248dc948b02de4e815b29",
           "version": null
         }
       },

--- a/DP3TApp/Logic/CheckIn/Helpers/QRCodePDFGenerator.swift
+++ b/DP3TApp/Logic/CheckIn/Helpers/QRCodePDFGenerator.swift
@@ -35,8 +35,7 @@ class QRCodePDFGenerator {
             label.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
             ctx.cgContext.translateBy(x: x, y: y)
 
-            let attrs = [NSAttributedString.Key.font: label.font!]
-            venue.draw(with: CGRect(x: 0, y: 0, width: size.width, height: size.height), options: .usesLineFragmentOrigin, attributes: attrs, context: nil)
+            label.layer.render(in: ctx.cgContext)
 
             ctx.cgContext.translateBy(x: -x, y: -y)
 

--- a/DP3TApp/SharedUI/Style/NSLabelType.swift
+++ b/DP3TApp/SharedUI/Style/NSLabelType.swift
@@ -287,6 +287,7 @@ public enum NSPDFLabelType: UBLabelType {
 
 class PDFLabel: UBLabel<NSPDFLabelType> {
     private var labelType: NSPDFLabelType
+    private var count = 0
 
     override init(_ type: NSPDFLabelType, textColor: UIColor? = nil, numberOfLines: Int = 0, textAlignment: NSTextAlignment = .left) {
         labelType = type
@@ -297,10 +298,17 @@ class PDFLabel: UBLabel<NSPDFLabelType> {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        count = 0
+    }
+
     override func draw(_ layer: CALayer, in ctx: CGContext) {
         let isPDF = !UIGraphicsGetPDFContextBounds().isEmpty
-
-        if !self.layer.shouldRasterize, isPDF {
+        if isPDF {
+            if count > 0 { draw(bounds) }
+            count += 1
+        } else if !layer.shouldRasterize {
             draw(bounds)
         } else {
             super.draw(layer, in: ctx)


### PR DESCRIPTION
The draw function of the PDFLabel gets called twice, and the first time it is drawn a little "off" if it has character larger than the box.
