### PR TITLE
Fixes covidcert deeplinking

### DIFF
--- a/DP3TApp/Screens/CheckIn/Scanner/NSCheckInViewController.swift
+++ b/DP3TApp/Screens/CheckIn/Scanner/NSCheckInViewController.swift
@@ -176,9 +176,11 @@ extension NSCheckInViewController: NSQRScannerViewDelegate {
         // Handle case where user tries to check in a covid certificate
         if str.starts(with: "HC1:") {
             let alert = UIAlertController(title: "", message: "covid_certificate_alert_text".ub_localized, preferredStyle: .alert)
-            if UIApplication.shared.canOpenURL(URL(string: "covidcert://")!) {
+            if UIApplication.shared.canOpenURL(URL(string: "chcovidcert://")!) {
                 alert.addAction(UIAlertAction(title: "covid_certificate_open_app".ub_localized, style: .default, handler: { _ in
-                    UIApplication.shared.open(URL(string: "covidcert://\(str)")!, options: [:], completionHandler: nil)
+                    guard let b64Encoded = str.data(using: .utf8)?.base64EncodedString(),
+                          let url = URL(string: "chcovidcert://\(b64Encoded)") else { return }
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }))
             } else {
                 alert.addAction(UIAlertAction(title: "covid_certificate_install_app".ub_localized, style: .default, handler: { _ in

--- a/DP3TApp/Screens/CheckIn/Scanner/NSCheckInViewController.swift
+++ b/DP3TApp/Screens/CheckIn/Scanner/NSCheckInViewController.swift
@@ -176,10 +176,10 @@ extension NSCheckInViewController: NSQRScannerViewDelegate {
         // Handle case where user tries to check in a covid certificate
         if str.starts(with: "HC1:") {
             let alert = UIAlertController(title: "", message: "covid_certificate_alert_text".ub_localized, preferredStyle: .alert)
-            if UIApplication.shared.canOpenURL(URL(string: "chcovidcert://")!) {
+            if UIApplication.shared.canOpenURL(URL(string: "covidcert://")!) {
                 alert.addAction(UIAlertAction(title: "covid_certificate_open_app".ub_localized, style: .default, handler: { _ in
-                    guard let b64Encoded = str.data(using: .utf8)?.base64EncodedString(),
-                          let url = URL(string: "chcovidcert://\(b64Encoded)") else { return }
+                    guard let urlEncoded = str.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+                          let url = URL(string: "covidcert://\(urlEncoded)") else { return }
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }))
             } else {

--- a/DP3TApp/Supporting Files/Info.plist
+++ b/DP3TApp/Supporting Files/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<string>chcovidcert</string>
+		<string>covidcert</string>
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>

--- a/DP3TApp/Supporting Files/Info.plist
+++ b/DP3TApp/Supporting Files/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<string>covidcert</string>
+		<string>chcovidcert</string>
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>


### PR DESCRIPTION
Change scheme to "chcovidcert" and base64 encodes QR-code before creating the URL.