### PR TITLE
Adds hint label for QR-Code generation in web

### DIFF
--- a/DP3TApp/Screens/CheckIn/Events/NSCreatedEventsViewController.swift
+++ b/DP3TApp/Screens/CheckIn/Events/NSCreatedEventsViewController.swift
@@ -21,6 +21,8 @@ class NSCreatedEventsViewController: NSViewController {
         return NSInfoBoxView(viewModel: model)
     }()
 
+    private let additionalInfoLabel = NSLinkifiedTextView(labelType: .textLight, textColor: .ns_defaultTextColor, linkLabelType: .textBold)
+
     override init() {
         super.init()
         NotificationCenter.default.addObserver(self, selector: #selector(updateTitle), name: .createdEventAdded, object: nil)
@@ -99,17 +101,27 @@ class NSCreatedEventsViewController: NSViewController {
 
         eventsModule.contentView.addSpacerView(NSPadding.medium + NSPadding.small)
         eventsModule.contentView.addArrangedView(eventsInfoBox)
+        eventsModule.contentView.addSpacerView(NSPadding.medium + NSPadding.small)
 
         eventsInfoBox.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(-(NSPadding.medium + NSPadding.small))
         }
-        eventsModule.contentView.addSpacerView(NSPadding.large)
+
+        eventsModule.contentView.addSpacerView(NSPadding.medium)
 
         eventsModule.contentView.addArrangedView(generateButton)
         generateButton.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(-(NSPadding.medium + NSPadding.small))
         }
-        eventsModule.contentView.addSpacerView(10)
+
+        eventsModule.contentView.addSpacerView(NSPadding.medium)
+
+        // add additional label with hint to qr-code generation in web
+        eventsModule.contentView.addArrangedView(additionalInfoLabel)
+
+        additionalInfoLabel.snp.remakeConstraints { make in
+            make.left.right.equalToSuperview().inset(-NSPadding.small)
+        }
 
         stackScrollView.addSpacerView(NSPadding.large)
 
@@ -138,7 +150,14 @@ class NSCreatedEventsViewController: NSViewController {
         infoBoxModule.ub_addShadow(radius: 4, opacity: 0.1, xOffset: 0, yOffset: -1)
 
         eventsInfoBox.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(NSPadding.medium)
+            make.top.left.right.equalToSuperview().inset(NSPadding.medium)
+        }
+
+        infoBoxModule.addSubview(additionalInfoLabel)
+        additionalInfoLabel.snp.remakeConstraints { make in
+            make.top.equalTo(eventsInfoBox.snp.bottom).offset(2.0 * NSPadding.medium)
+            make.bottom.equalToSuperview().inset(2.0 * NSPadding.medium)
+            make.left.right.equalToSuperview().inset(NSPadding.medium)
         }
 
         stackScrollView.addArrangedView(infoBoxModule)
@@ -157,6 +176,8 @@ class NSCreatedEventsViewController: NSViewController {
         let faqButton = NSButton.faqButton(color: .ns_blue)
         stackScrollView.addArrangedView(faqButton)
         stackScrollView.addSpacerView(NSPadding.large)
+
+        additionalInfoLabel.text = "checkin_generate_web_hint".ub_localized
     }
 
     deinit {

--- a/DP3TApp/Screens/CheckIn/Events/NSCreatedEventsViewController.swift
+++ b/DP3TApp/Screens/CheckIn/Events/NSCreatedEventsViewController.swift
@@ -21,7 +21,7 @@ class NSCreatedEventsViewController: NSViewController {
         return NSInfoBoxView(viewModel: model)
     }()
 
-    private let additionalInfoLabel = NSLinkifiedTextView(labelType: .textLight, textColor: .ns_defaultTextColor, linkLabelType: .textBold)
+    private let additionalInfoLabel = NSLabel(.textLight, textAlignment: .center)
 
     override init() {
         super.init()

--- a/DP3TApp/Screens/CheckIn/Events/NSQRCodeGenerationViewController.swift
+++ b/DP3TApp/Screens/CheckIn/Events/NSQRCodeGenerationViewController.swift
@@ -75,6 +75,7 @@ class NSQRCodeGenerationViewController: NSViewController {
         stackScrollView.addSpacerView(NSPadding.large)
         stackScrollView.addArrangedView(fillerView)
         stackScrollView.addArrangedView(createButton)
+
         stackScrollView.addSpacerView(NSPadding.large)
 
         createButton.isEnabled = false


### PR DESCRIPTION
Adds a hint label on the QR-code generation module view that the qr-codes can also be generated on the web. On purpose it's not clickable since the user in the app should use the app.