### PR TITLE
Sync ProblematicEvents also on appstart

### DIFF
--- a/DP3TApp/Logic/AppDelegate.swift
+++ b/DP3TApp/Logic/AppDelegate.swift
@@ -101,6 +101,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             DatabaseSyncer.shared.syncDatabaseIfNeeded()
         }
 
+        ProblematicEventsManager.shared.syncIfNeeded()
+
         window?.makeKey()
         if TracingManager.shared.isSupported {
             window?.rootViewController = navigationController


### PR DESCRIPTION
On app start, check if a sync is needed from the ProblematicEvents. If there has not been any check in two hours, then start the check.